### PR TITLE
Adiciona `ADCDriver`

### DIFF
--- a/ADCDriver/ADCDriver.cpp
+++ b/ADCDriver/ADCDriver.cpp
@@ -1,0 +1,15 @@
+/*
+  ADCDriver.cpp
+*/
+
+#include "ADCDriver.h"
+
+ADCDriver::ADCDriver() { }
+
+void ADCDriver::adc_config(uint16_t adc_freq) {
+  analogReference(adc_freq);
+}
+
+uint16_t ADCDriver::adc_read(uint8_t adc_chan) {
+  return analogRead(adc_chan);
+}

--- a/ADCDriver/ADCDriver.h
+++ b/ADCDriver/ADCDriver.h
@@ -1,0 +1,17 @@
+/*
+  ADCDriver.h
+*/
+
+#ifndef ADCDriver_h
+#define ADCDriver_h
+
+#include <Arduino.h>
+
+class ADCDriver {
+  public:
+    ADCDriver();
+    void adc_config(uint16_t adc_freq);
+    uint16_t adc_read(uint8_t adc_chan);
+};
+
+#endif

--- a/ADCDriver/ADCDriver.ino
+++ b/ADCDriver/ADCDriver.ino
@@ -1,0 +1,17 @@
+#include <ADCDriver.h>
+
+int analogPin = A3; // terminal do meio de um potênciometro conectado ao pino analógico 3
+                    // terminais mais externos são conectados um no ground e o outro em +5V
+int val = 0;        // variável para guardar o valor lido
+
+ADCDriver adc;
+
+void setup() {
+  adc.adc_config(INTERNAL1V1);
+  Serial.begin(9600);           // configura a porta serial
+}
+
+void loop() {
+  val = adc.adc_read(analogPin);    // lê o pino de entrada
+  Serial.println(val);          // imprime o valor na porta serial
+}


### PR DESCRIPTION
Adiciona o driver ADC para Arduino. Conforme a [doc](https://www.arduino.cc/reference/pt/language/functions/zero-due-mkr-family/analogreadresolution/) sobre `analogReadResolution`, não é possível setar a resolução do Arduino UNO e Mega, apenas nas placas Due, Zero e da família MKR. 